### PR TITLE
Configure release to only publish to npm

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,7 +23,6 @@
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
-    ],
-    "@semantic-release/github"
+    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
 		"@playwright/test": "^1.25.0",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
-		"@semantic-release/github": "^11.0.3",
 		"@semantic-release/npm": "^12.0.2",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",


### PR DESCRIPTION
Remove GitHub release configuration to only publish to NPM.

---

[Open in Web](https://cursor.com/agents?id=bc-7054dbbe-b801-41f0-9bdc-194b262a7857) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7054dbbe-b801-41f0-9bdc-194b262a7857) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)